### PR TITLE
Update README.md to remove old refs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,10 @@
 
 The instructor training course for The Carpentries which includes [Software Carpentry][swc-site], [Data Carpentry][dc-site], and [Library Carpentry][lc-site].
 Please see [https://carpentries.github.io/instructor-training/](https://carpentries.github.io/instructor-training/) for a rendered version of this material,
-[the lesson template documentation][lesson-example]
-for instructions on formatting, building, and submitting material,
-or run `make` in this directory for a list of helpful commands.
+[the lesson template documentation][lesson-doc]
+for instructions on formatting, building, and submitting material. 
+
+If you want to preview this lesson locally, you will need the [{sandpaper} R package](https://carpentries.github.io/sandpaper-docs/#setup) along with R and pandoc. Once you have those installed, you may preview the lesson locally by opening R inside this directory and using the command `sandpaper::serve()`
 
 **Maintainer(s):**
 
@@ -22,7 +23,7 @@ or run `make` in this directory for a list of helpful commands.
 [swc-site]: http://software-carpentry.org
 [dc-site]: http://datacarpentry.org
 [lc-site]: https://librarycarpentry.org
-[lesson-example]: https://carpentries.github.io/lesson-example
+[lesson-doc]: https://carpentries.github.io/sandpaper-docs
 [brown_sarah]: https://carpentries.org/instructors/#brownsarahm
 [dennis_tim]: https://carpentries.org/instructors/#jt14den
 [perez-suarez_david]: https://carpentries.org/instructors/#dpshelio


### PR DESCRIPTION
I've replaced lesson-example with sandpaper-docs and given my attempt at providing succinct instructions.

One of the things that the previous README did not do was to describe the toolchain necessary to even run `make`. 

This will address https://github.com/carpentries/instructor-training/issues/1515

Maintainers: feel free to make and accept any changes you wish.